### PR TITLE
Cookie actualizada

### DIFF
--- a/soldado-gym/package-lock.json
+++ b/soldado-gym/package-lock.json
@@ -537,7 +537,7 @@
         "body-parser": "1.20.3",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.6.0",
+        "cookie": ">=0.7.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",


### PR DESCRIPTION
Debido a un problema de vulnerabilidad de la dependencia cookie en su version 0.6.0, se realizó una actualizacion a la version 0.7.0